### PR TITLE
reduce information in the performance log

### DIFF
--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -127,8 +127,6 @@ class TestStats:
                     report.append('- %s' % t.check.current_partition.fullname)
                     previous_part = t.check.current_partition.fullname
 
-                report.append('   - %s' % t.check.current_environ)
-
             for key, ref in t.check.perfvalues.items():
                 var = key.split(':')[-1]
                 val = ref[0]
@@ -137,7 +135,7 @@ class TestStats:
                 except IndexError:
                     unit = '(no unit specified)'
 
-                report.append('      * %s: %s %s' % (var, val, unit))
+                report.append('   * %s: %s %s' % (var, val, unit))
 
         report.append(line_width * '-')
         return '\n'.join(report)

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -129,8 +129,6 @@ class TestStats:
 
                 report.append('   - %s' % t.check.current_environ)
 
-            report.append('      * num_tasks: %s' % t.check.num_tasks)
-
             for key, ref in t.check.perfvalues.items():
                 var = key.split(':')[-1]
                 val = ref[0]


### PR DESCRIPTION
We do not want these, as it makes the performance log noisy for when we send to slack.